### PR TITLE
bugfix for issue #40 and other boolean states not correctly set

### DIFF
--- a/main.js
+++ b/main.js
@@ -734,7 +734,9 @@ class Wled extends utils.Adapter {
 			this.createdStatesDetails[stateName] = common;
 
 			// Set value to state including expiration time
-			if (value) {
+			if (value == null) {
+				this.log.debug('Value is null or undefined for : ' + stateName);
+			} else {
 				await this.setState(stateName, {
 					val: value,
 					ack: true,


### PR DESCRIPTION
Fixes that `if (value)` is false for boolean value `false`, so the value is not set. Same for number 0 and empty string. Fixes #40 and possibly some other.